### PR TITLE
chore(lint): update lockfile-lint to enforce https

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "node scripts/test.js",
     "coverage": "node scripts/test.js --coverage --watchAll=false",
     "coveralls": "node scripts/test.js --coverage --watchAll=false --coverageReporters=text-lcov | coveralls",
-    "validate:lockfile": "lockfile-lint --path yarn.lock --type yarn --allowed-hosts yarn",
+    "validate:lockfile": "lockfile-lint --path yarn.lock --type yarn --allowed-hosts yarn --validate-https",
     "validate:ts": "tsc --lib 'es2015' --noEmit src/**/*.ts",
     "prepublishOnly": "node scripts/build.js"
   },


### PR DESCRIPTION
## Description

This is a subtle change but I updated lockfile-lint so that allowed hosts match a host and not a URL, so if your intention was also to enforce HTTPS usage, which was indeed the previous behavior, then you should now explicitly do so using the `validate-https` option

## Type of change

Update lockfile linter for developers on this project

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
