### PR TITLE
fix(Typescript): Add missing types

### DIFF
--- a/packages/web/index.d.ts
+++ b/packages/web/index.d.ts
@@ -112,6 +112,20 @@ export function withKeycloak<TPromise extends KeycloakPromiseType = 'native'>(
   component: ComponentType<ReactKeycloakInjectedProps<TPromise>>
 ): ComponentType
 
+export interface ReactKeycloakContextValue<
+  TPromise extends Keycloak.KeycloakPromiseType = 'native'
+> {
+  /**
+   * The single Keycloak instance of your application.
+   */
+  keycloak: KeycloakInstance<TPromise>;
+
+  /**
+   * Boolean indicating whenever the Keycloak instance has been initialized by KeycloakProvider
+   */
+  initialized: boolean;
+}
+
 /**
  *
  */


### PR DESCRIPTION
## Description

It seems like this type was forgotten about during the transition. I re-added this based on https://github.com/panz3r/react-keycloak/blob/b63d2f1f694ed524264213c9c7e4c5d6b9c4d957/src/lib/index.d.ts.

add ReactKeycloakContextValue back to index.d.ts

Fixes #37 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Typescript compile

**Test Configuration**:

* TypeScript: 3.7.3
* KeycloakJS version: ^8.0.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
