### PR TITLE
fix: add source map files to builds

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,6 +8,7 @@
       "dom"
     ],
     "sourceMap": true,
+    "inlineSources": true,
     "allowJs": false,
     "jsx": "react",
     "declaration": true,

--- a/packages/ssr/tsconfig.json
+++ b/packages/ssr/tsconfig.json
@@ -8,6 +8,7 @@
       "dom"
     ],
     "sourceMap": true,
+    "inlineSources": true,
     "allowJs": false,
     "jsx": "react",
     "declaration": true,

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -8,6 +8,7 @@
       "dom"
     ],
     "sourceMap": true,
+    "inlineSources": true,
     "allowJs": false,
     "jsx": "react",
     "declaration": true,


### PR DESCRIPTION
## Description

Fixes #100, #167, #176, #179

Adding TSConfig option `inlineSources` fixes "`Failed to parse source map`" webpack warning. Adds nominal weight to packages. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Built packages locally, referenced local packages in my application package.json (i.e.

```
"dependencies": {
  "@react-keycloak/web": "file:../react-keycloak/packages/web"`
}
```

...then executed `npm start` in my application -- no `failed to parse source map` (or other) warnings were shown.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
